### PR TITLE
47

### DIFF
--- a/src/scripts/nav-intersection-observer.js
+++ b/src/scripts/nav-intersection-observer.js
@@ -34,7 +34,7 @@ function createDebugOverlay() {
       z-index: 9999;
       border-bottom: 2px dashed red;
     ">
-      <span style="position: absolute; bottom: 4px; left: 8px; color: red; font-size: 12px; font-weight: bold;">
+      <span style="position: absolute; bottom: 4px; left: 8px; color: red; font-size: var(--font-size-xs); font-weight: bold;">
         ↑ IGNORED (top 33%)
       </span>
     </div>
@@ -49,7 +49,7 @@ function createDebugOverlay() {
       z-index: 9999;
       border-top: 2px dashed red;
     ">
-      <span style="position: absolute; top: 4px; left: 8px; color: red; font-size: 12px; font-weight: bold;">
+      <span style="position: absolute; top: 4px; left: 8px; color: red; font-size: var(--font-size-xs); font-weight: bold;">
         ↓ IGNORED (bottom 33%)
       </span>
     </div>
@@ -64,7 +64,7 @@ function createDebugOverlay() {
       z-index: 9998;
       border: 2px solid green;
     ">
-      <span style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); color: green; font-size: 14px; font-weight: bold;">
+      <span style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); color: green; font-size: var(--font-size-sm); font-weight: bold;">
         ACTIVE ZONE (middle ~34% of viewport)
       </span>
     </div>

--- a/src/styles/about-leadership.css
+++ b/src/styles/about-leadership.css
@@ -42,15 +42,31 @@
 }
 
 .about-intro {
+  text-align: center;
+  max-width: 40rem;
+  margin: 0 auto 1.5rem;
+}
+
+.about-body {
+  font-size: var(--font-size-base);
+  line-height: 1.6;
   max-width: 40rem;
   margin: 0 auto 1.5rem;
   border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  padding-bottom: 1.5rem;
 }
 
 .about-title {
-  font-size: var(--font-size-xl);
+  font-size: var(--font-size-3xl);
   font-weight: 700;
   margin-bottom: 0.75rem;
+  line-height: 1.2;
+}
+
+.about-title .text-lg {
+  font-size: var(--font-size-lg) !important;
+  opacity: 0.9;
+  margin-top: 0.5rem;
 }
 
 /* --------------------------------------------------------------------------
@@ -292,7 +308,7 @@
   right: 0.85rem;
   background: none;
   border: none;
-  font-size: 1.4rem;
+  font-size: clamp(1.2rem, 1.1rem + 0.5vw, 1.4rem);
   line-height: 1;
   color: rgba(148, 163, 184, 0.9);
   cursor: pointer;
@@ -328,7 +344,7 @@
   justify-content: center;
   flex-shrink: 0;
   font-weight: 700;
-  font-size: 1.35rem;
+  font-size: clamp(1.15rem, 1.05rem + 0.5vw, 1.35rem);
   letter-spacing: 0.06em;
   background: linear-gradient(135deg, var(--color-accent), #facc15);
   color: var(--color-on-primary);
@@ -378,7 +394,7 @@
 
 /* CTA (front card) */
 .staff-card__cta {
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-accent);
   font-weight: 600;
   margin-top: auto;

--- a/src/styles/contact.css
+++ b/src/styles/contact.css
@@ -29,6 +29,61 @@
     padding: clamp(1rem, calc(2vw + 1rem), 2rem);
   }
 
+  #contact > header {
+    margin-bottom: clamp(1.5rem, 3vw, 2rem);
+  }
+
+  #contact > header h2 {
+    text-align: center;
+    line-height: 1.2;
+  }
+
+  [data-component="ContactLayout"] {
+    gap: clamp(1.5rem, 3vw, 2rem);
+  }
+
+  [data-component="ContactContent"] {
+    gap: clamp(1.2rem, 2.5vw, 1.8rem);
+  }
+
+  #contact [data-component="IntroHero"] {
+    padding: clamp(1rem, calc(1.5vw + 0.5rem), 1.5rem);
+    text-align: center;
+  }
+
+  #contact [data-component="IntroHero"] h3 {
+    font-size: clamp(1.25rem, 1.1rem + 0.75vw, 1.5rem);
+    line-height: 1.3;
+    margin-bottom: clamp(0.75rem, 1.5vw, 1rem);
+  }
+
+  #contact [data-component="IntroHero"] p {
+    font-size: var(--font-size-sm);
+    line-height: 1.6;
+    max-width: none;
+  }
+
+  #contact [data-component="TrustHighlights"] {
+    margin-top: clamp(1rem, 2vw, 1.5rem);
+  }
+
+  #contact [data-component="TrustHighlights"] h3 {
+    font-size: var(--font-size-base);
+    margin-bottom: clamp(0.5rem, 1vw, 0.75rem);
+    text-align: center;
+  }
+
+  #contact [data-component="TrustHighlights"] ul {
+    justify-content: center;
+    gap: clamp(0.4rem, 1vw, 0.6rem);
+  }
+
+  #contact [data-component="TrustHighlights"] li {
+    font-size: var(--font-size-xs);
+    padding: clamp(0.4rem, 0.8vw, 0.6rem) clamp(0.5rem, 1vw, 0.75rem);
+    line-height: 1.3;
+  }
+
   #contact .form-field label {
     font-size: var(--font-size-xs);
   }
@@ -44,10 +99,10 @@
   }
 
   #contact #match-microcopy {
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-xs);
   }
 
-  #contact [data-component="TrustHighlights"] li {
+  #contact [data-component="RoleChips"] li {
     font-size: var(--font-size-xs);
   }
 
@@ -257,7 +312,7 @@ html[data-theme="dark"] #contact .role-chip[aria-pressed="true"] {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: var(--font-weight-bold);
   color: var(--color-on-primary);
   background:

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -94,7 +94,7 @@
   border-radius: 999px;
   padding: 0.65rem 1rem;
   font-weight: var(--font-weight-medium);
-  font-size: 0.95rem;
+  font-size: clamp(0.85rem, 0.8rem + 0.25vw, 0.95rem);
   line-height: 1;
   min-height: 42px;
   min-width: 96px;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -23,7 +23,7 @@
   color: #fff;
   padding: 0.5rem 1rem;
   text-decoration: none;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }
 
 .skip-link:focus {

--- a/src/styles/mobile-nav.css
+++ b/src/styles/mobile-nav.css
@@ -46,7 +46,7 @@
   min-height: 3rem;
   padding: 0.5rem 0.5rem 0.375rem;
   text-decoration: none;
-  font-size: 0.65rem;
+  font-size: clamp(0.6rem, 0.55rem + 0.25vw, 0.65rem);
   font-weight: var(--font-weight-medium);
   letter-spacing: 0.02em;
   text-transform: uppercase;


### PR DESCRIPTION
refactor: replace hardcoded font sizes with CSS custom properties and responsive clamp values

- replace hardcoded px font sizes with var(--font-size-*) custom properties in nav-intersection-observer debug overlay
- add text-align: center and max-width to .about-intro
- extract .about-body styles with font-size, line-height, and padding-bottom
- increase .about-title from xl to 3xl and add line-height
- add .about-title .text-lg styles with responsive font-size and opacity
- replace hardcoded font