### PR TITLE
Add office locations to contact section

### DIFF
--- a/sections/contact.html
+++ b/sections/contact.html
@@ -39,6 +39,13 @@
                             <span class="contact-icon">📱</span>
                             213-444-3284
                         </a>
+                        <div class="contact-item contact-locations">
+                            <span class="contact-icon">📍</span>
+                            <div class="locations-text">
+                                <span class="locations-label">Offices in:</span>
+                                <span class="locations-list">Orange County, Bay Area & Massachusetts</span>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/styles/contact.css
+++ b/src/styles/contact.css
@@ -240,3 +240,59 @@ html[data-theme="dark"] #contact {
   max-width: 46rem;
 }
 
+/* Office locations styling */
+.contact-locations {
+  cursor: default !important;
+  background: linear-gradient(
+    135deg,
+    rgba(34, 197, 94, 0.08) 0%,
+    rgba(34, 197, 94, 0.04) 100%);
+  border: 1px solid rgba(34, 197, 94, 0.2);
+}
+
+.contact-locations:hover {
+  transform: none;
+  background: linear-gradient(
+    135deg,
+    rgba(34, 197, 94, 0.08) 0%,
+    rgba(34, 197, 94, 0.04) 100%);
+  border: 1px solid rgba(34, 197, 94, 0.2);
+}
+
+.locations-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.locations-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  opacity: 0.8;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+.locations-list {
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--contact-text-on-surface);
+}
+
+/* Mobile optimizations for locations */
+@media (max-width: 768px) {
+  .locations-text {
+    gap: 0.25rem;
+  }
+  
+  .locations-label {
+    font-size: 0.7rem;
+  }
+  
+  .locations-list {
+    font-size: 0.8rem;
+    line-height: 1.4;
+  }
+}
+


### PR DESCRIPTION
Addresses issue #136

## Changes
- Added office locations under the phone number in the contact section
- Displays "Offices in: Orange County, Bay Area & Massachusetts"
- Styled with green accent to differentiate from clickable contact items
- Responsive design with proper mobile optimization
- Maintains consistent UI/UX with existing contact section design

## Implementation
- Added new `contact-locations` div with location icon and structured text
- Used semantic HTML with proper labeling
- Applied subtle green gradient background to distinguish from clickable items
- Disabled hover effects for non-interactive element
- Mobile-optimized typography and spacing

## Files Changed
- `sections/contact.html` - Added office locations markup
- `src/styles/contact.css` - Added styling for locations display